### PR TITLE
Remove redundant dependency. Update mbed dependency to mbed-core.

### DIFF
--- a/module.json
+++ b/module.json
@@ -19,12 +19,7 @@
     "mbed-net-lwip-eth"
   ],
   "dependencies": {
-    "mbed": "*",
+    "mbed-core": "*",
     "mbed-net-lwip": "~0.1.1"
-  },
-  "targetDependencies": {
-    "lwip-k64f": {
-      "mbed-net-lwip-k64f": "~0.0.3"
-    }
   }
 }


### PR DESCRIPTION
mbed-net-lwip-eth has a dependency on mbed-net-lwip, which handles target dependencies.  This makes any target dependencies in mbed-net-lwip-eth redundant.

@bogdanm 
