### PR TITLE
add Apache-2.0 license and headers

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,2 @@
+Unless specifically indicated otherwise in a file, files are licensed
+under the Apache 2.0 license, as can be found in: apache-2.0.txt

--- a/apache-2.0.txt
+++ b/apache-2.0.txt
@@ -1,0 +1,379 @@
+In addition to any license you have otherwise agreed to, parts of this software are licensed under the terms of the Apache Software License, 2.0. Please refer to license headers in the individual files.
+
+Copyright (c) 2006-2013 ARM Limited
+ 
+
+ 
+
+                                 Apache License 
+
+                           Version 2.0, January 2004 
+
+                        http://www.apache.org/licenses/ 
+
+ 
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION 
+
+ 
+
+   1. Definitions. 
+
+ 
+
+      "License" shall mean the terms and conditions for use, 
+reproduction, 
+
+      and distribution as defined by Sections 1 through 9 of this 
+document. 
+
+ 
+
+      "Licensor" shall mean the copyright owner or entity authorized by 
+
+      the copyright owner that is granting the License. 
+
+ 
+
+      "Legal Entity" shall mean the union of the acting entity and all 
+
+      other entities that control, are controlled by, or are under common 
+
+      control with that entity. For the purposes of this definition, 
+
+      "control" means (i) the power, direct or indirect, to cause the 
+
+      direction or management of such entity, whether by contract or 
+
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the 
+
+      outstanding shares, or (iii) beneficial ownership of such entity. 
+
+ 
+
+      "You" (or "Your") shall mean an individual or Legal Entity 
+
+      exercising permissions granted by this License. 
+
+ 
+
+      "Source" form shall mean the preferred form for making 
+modifications, 
+
+      including but not limited to software source code, documentation 
+
+      source, and configuration files. 
+
+ 
+
+      "Object" form shall mean any form resulting from mechanical 
+
+      transformation or translation of a Source form, including but 
+
+      not limited to compiled object code, generated documentation, 
+
+      and conversions to other media types. 
+
+ 
+
+      "Work" shall mean the work of authorship, whether in Source or 
+
+      Object form, made available under the License, as indicated by a 
+
+      copyright notice that is included in or attached to the work 
+
+      (an example is provided in the Appendix below). 
+
+ 
+
+      "Derivative Works" shall mean any work, whether in Source or Object 
+
+      form, that is based on (or derived from) the Work and for which the 
+
+      editorial revisions, annotations, elaborations, or other 
+modifications 
+
+      represent, as a whole, an original work of authorship. For the 
+purposes 
+
+      of this License, Derivative Works shall not include works that 
+remain 
+
+      separable from, or merely link (or bind by name) to the interfaces 
+of, 
+
+      the Work and Derivative Works thereof. 
+
+ 
+
+      "Contribution" shall mean any work of authorship, including 
+
+      the original version of the Work and any modifications or additions 
+
+      to that Work or Derivative Works thereof, that is intentionally 
+
+      submitted to Licensor for inclusion in the Work by the copyright 
+owner 
+
+      or by an individual or Legal Entity authorized to submit on behalf 
+of 
+
+      the copyright owner. For the purposes of this definition, 
+"submitted" 
+
+      means any form of electronic, verbal, or written communication sent 
+
+      to the Licensor or its representatives, including but not limited 
+to 
+
+      communication on electronic mailing lists, source code control 
+systems, 
+
+      and issue tracking systems that are managed by, or on behalf of, 
+the 
+
+      Licensor for the purpose of discussing and improving the Work, but 
+
+      excluding communication that is conspicuously marked or otherwise 
+
+      designated in writing by the copyright owner as "Not a 
+Contribution." 
+
+ 
+
+      "Contributor" shall mean Licensor and any individual or Legal 
+Entity 
+
+      on behalf of whom a Contribution has been received by Licensor and 
+
+      subsequently incorporated within the Work. 
+
+ 
+
+   2. Grant of Copyright License. Subject to the terms and conditions of 
+
+      this License, each Contributor hereby grants to You a perpetual, 
+
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable 
+
+      copyright license to reproduce, prepare Derivative Works of, 
+
+      publicly display, publicly perform, sublicense, and distribute the 
+
+      Work and such Derivative Works in Source or Object form. 
+
+ 
+
+   3. Grant of Patent License. Subject to the terms and conditions of 
+
+      this License, each Contributor hereby grants to You a perpetual, 
+
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable 
+
+      (except as stated in this section) patent license to make, have 
+made, 
+
+      use, offer to sell, sell, import, and otherwise transfer the Work, 
+
+      where such license applies only to those patent claims licensable 
+
+      by such Contributor that are necessarily infringed by their 
+
+      Contribution(s) alone or by combination of their Contribution(s) 
+
+      with the Work to which such Contribution(s) was submitted. If You 
+
+      institute patent litigation against any entity (including a 
+
+      cross-claim or counterclaim in a lawsuit) alleging that the Work 
+
+      or a Contribution incorporated within the Work constitutes direct 
+
+      or contributory patent infringement, then any patent licenses 
+
+      granted to You under this License for that Work shall terminate 
+
+      as of the date such litigation is filed. 
+
+ 
+
+   4. Redistribution. You may reproduce and distribute copies of the 
+
+      Work or Derivative Works thereof in any medium, with or without 
+
+      modifications, and in Source or Object form, provided that You 
+
+      meet the following conditions: 
+
+ 
+
+      (a) You must give any other recipients of the Work or 
+
+          Derivative Works a copy of this License; and 
+
+ 
+
+      (b) You must cause any modified files to carry prominent notices 
+
+          stating that You changed the files; and 
+
+ 
+
+      (c) You must retain, in the Source form of any Derivative Works 
+
+          that You distribute, all copyright, patent, trademark, and 
+
+          attribution notices from the Source form of the Work, 
+
+          excluding those notices that do not pertain to any part of 
+
+          the Derivative Works; and 
+
+ 
+
+      (d) If the Work includes a "NOTICE" text file as part of its 
+
+          distribution, then any Derivative Works that You distribute 
+must 
+
+          include a readable copy of the attribution notices contained 
+
+          within such NOTICE file, excluding those notices that do not 
+
+          pertain to any part of the Derivative Works, in at least one 
+
+          of the following places: within a NOTICE text file distributed 
+
+          as part of the Derivative Works; within the Source form or 
+
+          documentation, if provided along with the Derivative Works; or, 
+
+          within a display generated by the Derivative Works, if and 
+
+          wherever such third-party notices normally appear. The contents 
+
+          of the NOTICE file are for informational purposes only and 
+
+          do not modify the License. You may add Your own attribution 
+
+          notices within Derivative Works that You distribute, alongside 
+
+          or as an addendum to the NOTICE text from the Work, provided 
+
+          that such additional attribution notices cannot be construed 
+
+          as modifying the License. 
+
+ 
+
+      You may add Your own copyright statement to Your modifications and 
+
+      may provide additional or different license terms and conditions 
+
+      for use, reproduction, or distribution of Your modifications, or 
+
+      for any such Derivative Works as a whole, provided Your use, 
+
+      reproduction, and distribution of the Work otherwise complies with 
+
+      the conditions stated in this License. 
+
+ 
+
+   5. Submission of Contributions. Unless You explicitly state otherwise, 
+
+      any Contribution intentionally submitted for inclusion in the Work 
+
+      by You to the Licensor shall be under the terms and conditions of 
+
+      this License, without any additional terms or conditions. 
+
+      Notwithstanding the above, nothing herein shall supersede or modify 
+
+      the terms of any separate license agreement you may have executed 
+
+      with Licensor regarding such Contributions. 
+
+ 
+
+   6. Trademarks. This License does not grant permission to use the trade 
+
+      names, trademarks, service marks, or product names of the Licensor, 
+
+      except as required for reasonable and customary use in describing 
+the 
+
+      origin of the Work and reproducing the content of the NOTICE file. 
+
+ 
+
+   7. Disclaimer of Warranty. Unless required by applicable law or 
+
+      agreed to in writing, Licensor provides the Work (and each 
+
+      Contributor provides its Contributions) on an "AS IS" BASIS, 
+
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+
+      implied, including, without limitation, any warranties or 
+conditions 
+
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A 
+
+      PARTICULAR PURPOSE. You are solely responsible for determining the 
+
+      appropriateness of using or redistributing the Work and assume any 
+
+      risks associated with Your exercise of permissions under this 
+License. 
+
+ 
+
+   8. Limitation of Liability. In no event and under no legal theory, 
+
+      whether in tort (including negligence), contract, or otherwise, 
+
+      unless required by applicable law (such as deliberate and grossly 
+
+      negligent acts) or agreed to in writing, shall any Contributor be 
+
+      liable to You for damages, including any direct, indirect, special, 
+
+      incidental, or consequential damages of any character arising as a 
+
+      result of this License or out of the use or inability to use the 
+
+      Work (including but not limited to damages for loss of goodwill, 
+
+      work stoppage, computer failure or malfunction, or any and all 
+
+      other commercial damages or losses), even if such Contributor 
+
+      has been advised of the possibility of such damages. 
+
+ 
+
+   9. Accepting Warranty or Additional Liability. While redistributing 
+
+      the Work or Derivative Works thereof, You may choose to offer, 
+
+      and charge a fee for, acceptance of support, warranty, indemnity, 
+
+      or other liability obligations and/or rights consistent with this 
+
+      License. However, in accepting such obligations, You may act only 
+
+      on Your own behalf and on Your sole responsibility, not on behalf 
+
+      of any other Contributor, and only if You agree to indemnify, 
+
+      defend, and hold each Contributor harmless for any liability 
+
+      incurred by, or claims asserted against, such Contributor by reason 
+
+      of your accepting any such warranty or additional liability. 
+
+ 
+
+   END OF TERMS AND CONDITIONS
+

--- a/module.json
+++ b/module.json
@@ -9,12 +9,7 @@
     "ethernet"
   ],
   "author": "brendan.moran@arm.com",
-  "licenses": [
-    {
-      "url": "http://developer.mbed.org/handbook/MIT-Licence",
-      "type": "MIT"
-    }
-  ],
+  "license": "Apache-2.0",
   "extraIncludes": [
     "sal-iface-eth"
   ],

--- a/sal-iface-eth/EthernetInterface.h
+++ b/sal-iface-eth/EthernetInterface.h
@@ -1,20 +1,18 @@
-/* EthernetInterface.h */
-/* Copyright (C) 2012 mbed.org, MIT License
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy of this software
- * and associated documentation files (the "Software"), to deal in the Software without restriction,
- * including without limitation the rights to use, copy, modify, merge, publish, distribute,
- * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in all copies or
- * substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
- * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
- * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
- * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+/*
+ * Copyright (c) 2012-2015, ARM Limited, All Rights Reserved
+ * SPDX-License-Identifier: Apache-2.0
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #ifndef ETHERNETINTERFACE_H_

--- a/sal-iface-eth/eth_arch.h
+++ b/sal-iface-eth/eth_arch.h
@@ -1,20 +1,18 @@
-/* EthernetInterface.h */
-/* Copyright (C) 2012 mbed.org, MIT License
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy of this software
- * and associated documentation files (the "Software"), to deal in the Software without restriction,
- * including without limitation the rights to use, copy, modify, merge, publish, distribute,
- * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in all copies or
- * substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
- * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
- * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
- * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+/*
+ * Copyright (c) 2012-2015, ARM Limited, All Rights Reserved
+ * SPDX-License-Identifier: Apache-2.0
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 // Architecture specific Ethernet interface

--- a/source/EthernetInterface.cpp
+++ b/source/EthernetInterface.cpp
@@ -1,21 +1,20 @@
-/* EthernetInterface.cpp */
-/* Copyright (C) 2012 mbed.org, MIT License
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy of this software
- * and associated documentation files (the "Software"), to deal in the Software without restriction,
- * including without limitation the rights to use, copy, modify, merge, publish, distribute,
- * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in all copies or
- * substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
- * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
- * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
- * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+/*
+ * Copyright (c) 2012-2015, ARM Limited, All Rights Reserved
+ * SPDX-License-Identifier: Apache-2.0
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
+
 #include "EthernetInterface.h"
 
 #include "lwip/inet.h"


### PR DESCRIPTION
I've changed the existing MIT license since I believe these files are original to mbed and can be relicensed for inclusion in the mbed OS release (they contained only an mbed copyright declaration). If this is not the case please shout!

@bogdanm @bremoran 
