### PR TITLE
Implement a timeout for EthernetInterface::connect.

### DIFF
--- a/source/EthernetInterface.cpp
+++ b/source/EthernetInterface.cpp
@@ -124,17 +124,12 @@ int EthernetInterface::connect(unsigned int timeout_ms) {
     }
     _timeout.detach();
 
-#define min(A,B) \
-    ((A) < (B) ? (A) : (B))
-#define max(A,B) \
-    ((A) > (B) ? (A) : (B))
-
-    if (min(link_up, if_up) < 0) {
-        return min(link_up, if_up);
-    } else if ((link_up == 0) && (if_up == 0)) {
-        return 0;
+    if (link_up < 0 || if_up < 0) {
+        return -1;
+    } else if (link_up == 0 && if_up == 0) {
+        return -1;
     } else {
-        return max(link_up, if_up);
+        return 0;
     }
 }
 


### PR DESCRIPTION
Use a ```mbed::Timeout``` to stop DHCP attempts after the specified timeout.  This is still a blocking implementation.  A non-blocking EthernetInterface is still planned.

Fixes #2 

cc @bogdanm 